### PR TITLE
新しいチャットルームを作成する場合の処理について

### DIFF
--- a/client.py
+++ b/client.py
@@ -58,11 +58,25 @@ class Client():
         return
 
     def send_username(self):
-        user_name = self.encoder(self.username)
+        #user_name = self.encoder(self.username)
 
+        #送信の際のheaderの作成
+        user_name_to_byte = self.encoder(self.username)
+        user_name_byte_size = len(user_name_to_byte)
+
+        header = self.custom_tcp_header(user_name_byte_size,1,1,user_name_byte_size)
+
+        body = self.encoder(self.username) + self.encoder(self.username)
+
+        # user name
         sent_user_name = self.socket.sendto(
-            user_name, (self.server_address, self.server_port))
+            header+body, (self.server_address, self.server_port))
         print('Send {} bytes'.format(sent_user_name))
+
+        # sent_user_name = self.socket.sendto(
+        #     user_name, (self.server_address, self.server_port))
+        # print('Send {} bytes'.format(sent_user_name))
+
 
         # ユーザー名受信
         print('waiting to receive username')
@@ -99,6 +113,16 @@ class Client():
         finally:
             print('closing socket')
             self.socket.close()
+
+    def custom_tcp_header(self, room_name_size, operation, state, operation_payload_size):
+        room_name_size = room_name_size.to_bytes(1, byteorder='big')
+        operation = operation.to_bytes(1, byteorder='big')
+        state = state.to_bytes(1, byteorder='big')
+        operation_payload_size = operation_payload_size.to_bytes(29, byteorder='big')
+
+        return room_name_size + operation + state + operation_payload_size
+
+
 
 
 def main():

--- a/client.py
+++ b/client.py
@@ -87,7 +87,7 @@ class Client():
 
         # header解析
         room_name_size =  int.from_bytes(header[:1], byteorder='big')
-        print('room_size: received {} bytes data: {}'.format(
+        print('\nroom_size: received {} bytes data: {}'.format(
             len(header[:1]), room_name_size))
         operation = int.from_bytes(header[1:2],byteorder='big')
         print('operation: received {} bytes data: {}'.format(
@@ -136,6 +136,33 @@ class Client():
                 # 応答を受信
                 data, _ = self.socket.recvfrom(Client.BUFFER_SIZE)
                 print('\n received {!r}'.format(data))
+                # データ解析
+                header = data[:32]
+                body = data[32:]
+
+                # header解析
+                room_name_size =  int.from_bytes(header[:1], byteorder='big')
+                print('\nroom_size: received {} bytes data: {}'.format(
+                    len(header[:1]), room_name_size))
+                operation = int.from_bytes(header[1:2],byteorder='big')
+                print('operation: received {} bytes data: {}'.format(
+                    len(header[1:2]), operation))
+                state = int.from_bytes(header[2:3], byteorder='big')
+                print('state: received {} bytes data: {}'.format(
+                    len(header[2:3]), state))
+
+                operation_payload_size = int.from_bytes(header[3:32], byteorder='big')
+                print('payload_size: received {} bytes data: {}'.format(
+                    len(header[3:32]), operation_payload_size))
+
+                # body解析
+                room_name = self.decoder(body[:room_name_size])
+                print('room_name: received {} bytes data: {}'.format(
+                    len(body[:room_name_size]), room_name))
+
+                operation_payload = self.decoder(body[room_name_size:room_name_size + operation_payload_size])
+                print('user_name: received {} bytes data: {}'.format(
+                    len(body[room_name_size:room_name_size + operation_payload_size]), operation_payload))
 
         finally:
             print('closing socket')

--- a/client.py
+++ b/client.py
@@ -82,6 +82,32 @@ class Client():
         print('waiting to receive username')
         data, _ = self.socket.recvfrom(Client.BUFFER_SIZE)
         print('\n received username {!r}'.format(data))
+        header = data[:32]
+        body = data[32:]
+
+        # header解析
+        room_name_size =  int.from_bytes(header[:1], byteorder='big')
+        print('room_size: received {} bytes data: {}'.format(
+            len(header[:1]), room_name_size))
+        operation = int.from_bytes(header[1:2],byteorder='big')
+        print('operation: received {} bytes data: {}'.format(
+            len(header[1:2]), operation))
+        state = int.from_bytes(header[2:3], byteorder='big')
+        print('state: received {} bytes data: {}'.format(
+            len(header[2:3]), state))
+
+        # body解析
+        room_name = self.decoder(body[:room_name_size])
+        print('room_name: received {} bytes data: {}'.format(
+            len(body[:room_name_size]), room_name))
+
+        operation_payload_size = int.from_bytes(header[3:32], byteorder='big')
+        print('payload_size: received {} bytes data: {}'.format(
+            len(header[3:32]), operation_payload_size))
+
+        operation_payload = int.from_bytes(body[room_name_size:room_name_size + operation_payload_size], byteorder='big')
+        print('user_name: received {} bytes data: {}'.format(len(body[room_name_size:room_name_size + operation_payload_size]), operation_payload))
+
         return
 
     def send_message(self):
@@ -110,6 +136,7 @@ class Client():
                 # 応答を受信
                 data, _ = self.socket.recvfrom(Client.BUFFER_SIZE)
                 print('\n received {!r}'.format(data))
+
         finally:
             print('closing socket')
             self.socket.close()

--- a/server.py
+++ b/server.py
@@ -2,7 +2,7 @@ import socket
 import threading
 import time
 from chatroom import ChatRoom
-
+import uuid
 
 class Server():
     BUFFER_SIZE = 4096
@@ -17,6 +17,8 @@ class Server():
         # ソケットを特殊なアドレス0.0.0.0とポート9001に紐付け
         self.socket.bind((server_address, server_port))
         self.active_clients = {}
+        # ユーザー名とトークンを関連付ける
+        self.user_tokens = {}
 
     def start(self):
         # 受信を待ち受ける処理とタイムアウトのチェック処理を並列実行する
@@ -94,6 +96,13 @@ class Server():
         finally:
             print('closing socket')
             self.socket.close()
+
+
+def generate_user_token(self, username):
+    user_token = str(uuid.uuid4())
+    self.user_tokens[user_token] = username
+
+    return user_token
 
 
 def main():

--- a/server.py
+++ b/server.py
@@ -52,7 +52,7 @@ class Server():
 
                 # header解析
                 room_name_size =  int.from_bytes(header[:1], byteorder='big')
-                print('room_size: received {} bytes data: {}'.format(
+                print('\nroom_size: received {} bytes data: {}'.format(
                     len(header[:1]), room_name_size))
                 operation = int.from_bytes(header[1:2],byteorder='big')
                 print('operation: received {} bytes data: {}'.format(
@@ -136,7 +136,6 @@ class Server():
     def initialize_chat_room(self,room_name, username, client_address):
         # 即レスポンスを返す処理。
         print('Start initialize room.')
-        room_name_tobyte = self.encoder(room_name)
 
         operation_payload = 200
         operation_payload_tobyte = operation_payload.to_bytes(1, byteorder='big')
@@ -147,8 +146,14 @@ class Server():
         self.socket.sendto(header+body, client_address)
         host_token = generate_user_token()
         self.user_tokens[host_token] = username
+
         # host_tokenを含んだレスポンス返却処理(payloadに入れて送り返す等)
-        self.socket.sendto(self.encoder(host_token), client_address)
+        token_tobyte = self.encoder(host_token)
+        room_name_tobyte = self.encoder(room_name)
+        token_response_header = self.custom_tcp_header(len(room_name_tobyte),1,2,len(token_tobyte))
+        body = room_name_tobyte + token_tobyte
+
+        self.socket.sendto(token_response_header+body, client_address)
 
 
     def custom_tcp_header(self, room_name_size, operation, state, operation_payload_size):

--- a/server.py
+++ b/server.py
@@ -46,6 +46,20 @@ class Server():
                     len(data), client_address))
                 print(data)
 
+                # データ解析
+                header = data[:32]
+                body = data[32:]
+
+                # header
+                room_name_size = int.from_bytes(data[:1], byteorder='big')
+                operation = int.from_bytes(data[1:2], byteorder='big')
+                state = int.from_bytes(data[2:3], byteorder='big')
+                operation_payload_size = int.from_bytes(data[3:32], byteorder='big')
+
+                # body
+                room_name = body[:room_name_size]
+                operation_payload = body[room_name_size:room_name_size + operation_payload_size]
+
                 # データ準備
                 username_len = int.from_bytes(data[:1], byteorder='big')
                 username = self.decoder(data[1:1 + username_len])


### PR DESCRIPTION
# 概要
- クライアントはサーバーへチャットルーム作成のリクエストを送信する
- サーバーはチャットルーム作成を許可し、クライアントへホストトークンを送る

# 確認方法
cli上での確認
- [ ] `python3 server.py`でサーバ起動
- [ ] `python3 client.py`でクライアント起動しユーザ名を入力
- [ ] ユーザ名入力後の処理でcliに表示された内容が仕様通りになっているか。
- [ ] その他、コードを見ていただきご確認をお願いいたします。

# 実装内容

### 全体
- [ ] 一部のコードをコメントアウト

### server.py

- [ ] def receive_message

  - 変更内容：
      - 受信したデータのheader,bodyの解析する部分の追加
      - 解析の結果、operationが1のときinitialize_chat_room()の処理を動かす。

- [ ] def initialize_chat_room

  - チャットルームの初期化に関する操作を行う関数
  - 新規追加内容
      - header, bodyを生成し、即クライアントへステータスコード：200をレスポンスする。
      - generate_user_tokenを呼び出し、トークンの作成。
      - トークンとユーザ名を辞書(self.user_tokens = {})に格納し紐付ける
      - header, bodyを生成し、クライアントへトークンとルーム名をレスポンスする。

- [ ] def generate_user_token
    - トークンを生成する関数

- [ ] def custom_tcp_header
  - レスポンスを行う際のヘッダーを生成する関数


### client.py
- [ ] def send_username
  - 修正点
    - header, bodyつきでリクエストを送信する機能の追加
    - サーバから送られたものをheader, bodyに分けて解析する機能の追加。


- [ ] def receive_message
  - 修正点
    - サーバから送られたものをheader, bodyに分けて解析する機能の追加。

- [ ] def custom_tcp_header
  - レスポンスを行う際のヘッダーを生成する関数

### 懸念点
- エラーが起きた際の処理をより詳細に記載するかどうか
- decode,encode部分はyadonさんが作られたものを、tcp部分はkanataさんが作られたものに置き換える必要ありと考えています。