### PR TITLE
チャットルームに参加する際の処理について

### DIFF
--- a/client.py
+++ b/client.py
@@ -14,6 +14,7 @@ class Client():
         self.client_address = self.socket.getsockname()[0]
         self.client_port = self.socket.getsockname()[1]
         self.username = ''
+        self.user_token = None
         self.namesize = 0
 
         self.socket.bind((self.client_address, self.client_port))
@@ -99,8 +100,8 @@ class Client():
         print('Send {} bytes'.format(sent_user_name))
 
 
-        # ユーザー名受信
-        print('waiting to receive username')
+        # データ受信
+        print('waiting to receive data from server')
         data, _ = self.socket.recvfrom(Client.BUFFER_SIZE)
         print('\n received username {!r}'.format(data))
         header = data[:32]
@@ -181,9 +182,14 @@ class Client():
                 print('room_name: received {} bytes data: {}'.format(
                     len(body[:room_name_size]), room_name))
 
-                operation_payload = self.decoder(body[room_name_size:room_name_size + operation_payload_size], 'str')
+                #operation_payload = self.decoder(body[room_name_size:room_name_size + operation_payload_size], 'str')
+                operation_payload = self.decoder(body[room_name_size:room_name_size + operation_payload_size],'dict')
                 print('user_name: received {} bytes data: {}'.format(
                     len(body[room_name_size:room_name_size + operation_payload_size]), operation_payload))
+
+                if state == 2 and operation_payload["status_code"] == 200:
+                    self.user_token = operation_payload["user_token"]
+                print(self.user_token)
 
         finally:
             print('closing socket')
@@ -199,7 +205,7 @@ class Client():
 
     def select_action_mode(self):
         while True:
-            type = input('チャットルームを新規作成する場合は「1」、チャットルームに参加する場合は「2」を入力してください')
+            type = input('チャットルームを新規作成する場合は「1」、チャットルームに参加する場合は「2」を入力してください: ')
             if type == "1" :
                 return 1
             elif type == "2" :

--- a/client.py
+++ b/client.py
@@ -22,11 +22,14 @@ class Client():
         print(
             f'client address:{self.client_address}, client port:{self.client_port}')
 
+        #チャットルーム新規作成か参加か選ぶ
+        operation_type = self.select_action_mode()
+
         # ユーザー名セット
         self.set_username()
 
         # ユーザー名送信
-        self.send_username()
+        self.send_username(operation_type)
 
         # ユーザーからの入力を送信する処理とサーバーから受信する処理を並列実行する
         thread_send_message = threading.Thread(
@@ -78,15 +81,14 @@ class Client():
             break
         return
 
-    def send_username(self):
+    def send_username(self, operation):
         #user_name = self.encoder(self.username)
 
         #送信の際のheaderの作成
         user_name_to_byte = self.encoder(self.username, 1)
         user_name_byte_size = len(user_name_to_byte)
 
-        #headerの生成
-        header = self.custom_tcp_header(user_name_byte_size,1,1,user_name_byte_size)
+        header = self.custom_tcp_header(user_name_byte_size,operation,1,user_name_byte_size)
 
         #bodyの生成
         body = self.encoder(self.username, 1) + self.encoder(self.username, 1)
@@ -195,11 +197,15 @@ class Client():
 
         return room_name_size + operation + state + operation_payload_size
 
-# tcpクラスはここから
-# class tcp_client():
-
-
-
+    def select_action_mode(self):
+        while True:
+            type = input('チャットルームを新規作成する場合は「1」、チャットルームに参加する場合は「2」を入力してください')
+            if type == "1" :
+                return 1
+            elif type == "2" :
+                return 2
+            else:
+               print('入力を受け取ることができませんでした。')
 
 def main():
     client = Client()
@@ -208,5 +214,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-
-

--- a/client.py
+++ b/client.py
@@ -29,19 +29,20 @@ class Client():
         # ユーザー名セット
         self.set_username()
 
+        chatroom_name = self.input_room_name()
         # ユーザー名送信
-        self.send_username(operation_type)
+        self.send_username(operation_type, chatroom_name)
 
         # ユーザーからの入力を送信する処理とサーバーから受信する処理を並列実行する
-        thread_send_message = threading.Thread(
-            target=self.send_message, daemon=True)
+        # thread_send_message = threading.Thread(
+        #     target=self.send_message, daemon=True)
         thread_receive_message = threading.Thread(
             target=self.receive_message, daemon=True)
 
-        thread_send_message.start()
+        #thread_send_message.start()
         thread_receive_message.start()
 
-        thread_send_message.join()
+        #thread_send_message.join()
         thread_receive_message.join()
 
     # def encoder(self, data: str) -> bytes:
@@ -82,17 +83,19 @@ class Client():
             break
         return
 
-    def send_username(self, operation):
+    def send_username(self, operation, chatroom_name):
         #user_name = self.encoder(self.username)
 
         #送信の際のheaderの作成
         user_name_to_byte = self.encoder(self.username, 1)
         user_name_byte_size = len(user_name_to_byte)
 
-        header = self.custom_tcp_header(user_name_byte_size,operation,1,user_name_byte_size)
+        chatroom_name_to_byte = self.encoder(chatroom_name, 1)
+        chatroom_name_byte_size = len(chatroom_name_to_byte)
 
-        #bodyの生成
-        body = self.encoder(self.username, 1) + self.encoder(self.username, 1)
+        header = self.custom_tcp_header(chatroom_name_byte_size,operation,1,user_name_byte_size)
+
+        body = chatroom_name_to_byte + self.encoder(self.username, 1)
 
         #メッセージの送信
         sent_user_name = self.socket.sendto(
@@ -189,11 +192,17 @@ class Client():
 
                 if state == 2 and operation_payload["status_code"] == 200:
                     self.user_token = operation_payload["user_token"]
-                print(self.user_token)
+                    self.tcpr_end_udp_start()
+                    print(self.user_token)
+                    break
+                elif state == 2 and operation_payload["status_code"] == 404:
+                    print("チャットルームが存在しません、最初からやり直します。")
+                    self.start()
+                    break
 
         finally:
             print('closing socket')
-            self.socket.close()
+            #self.socket.close()
 
     def custom_tcp_header(self, room_name_size, operation, state, operation_payload_size):
         room_name_size = room_name_size.to_bytes(1, byteorder='big')
@@ -212,6 +221,18 @@ class Client():
                 return 2
             else:
                print('入力を受け取ることができませんでした。')
+
+    def input_room_name(self):
+        while True:
+            room_name = input('チャットルームの名前を入力してください。: ')
+            if room_name:
+                return room_name
+            else:
+                print('ルーム名が確認できません。')
+
+    def tcpr_end_udp_start(self):
+        print('udpに移行します。')
+        self.socket.close()
 
 def main():
     client = Client()

--- a/server.py
+++ b/server.py
@@ -338,13 +338,14 @@ class tcp_Server:
 
         # print(self.chat_rooms)
 
+        # host_tokenを含んだレスポンス返却処理(payloadに入れて送り返す等)
+        #token_tobyte = self.encoder(host_token, 1)
+        token_json = self.custom_tcp_body_by_json(200,host_token)
+        token_json_encoded = self.encoder(self.encoder(token_json))
 
-
-        # Return the response with the host token
-        token_tobyte = self.encoder(host_token, 1)
         room_name_tobyte = self.encoder(room_name, 1)
-        token_response_header = self.custom_tcp_header(len(room_name_tobyte), 1, 2, len(token_tobyte))
-        body = room_name_tobyte + token_tobyte
+        token_response_header = self.custom_tcp_header(len(room_name_tobyte),1,2,len(token_json_encoded))
+        body = room_name_tobyte + token_json_encoded
 
         # Send the message
         self.socket.sendto(token_response_header + body, client_address)

--- a/server.py
+++ b/server.py
@@ -370,23 +370,25 @@ class tcp_Server:
 
         # roomが見つからなかったとき、404レスポンス
         # try:
-        #     visitor_token = generate_user_token()
-        #     token_tobyte = self.encoder(visitor_token, 1)
+        #     member_token = generate_user_token()
         #     room_name_tobyte = self.encoder(room_name, 1)
-        #     self.chat_rooms[room_name]['members'].add((visitor_token, client_address))
+        #     self.chat_rooms[room_name]['members'].add((member_token, client_address))
 
         # except KeyError:
         #     print('ルームが存在しない')
-        #     operation_payload = 403
-        #     operation_payload_tobyte =self.encoder(operation_payload, 2)
+        #     operation_payload = self.custom_tcp_body_by_json(404,None)
+        #     operation_payload_tobyte =self.encoder(self.encoder(operation_payload))
         #     header = self.custom_tcp_header(0,2,2,len(operation_payload_tobyte))
         #     body = operation_payload_tobyte
         #     self.socket.sendto(header+body, client_address)
 
         # else:
-        #     token_response_header = self.custom_tcp_header(len(room_name_tobyte),1,2,len(token_tobyte))
-        #     token_response_body = room_name_tobyte + token_tobyte
-        #     self.socket.sendto(token_response_header+token_response_body, client_address)
+        #     body_json = self.custom_tcp_body_by_json(200,member_token)
+        #     body_json_encoded = self.encoder(self.encoder(body_json))
+
+        #     member_response_header = self.custom_tcp_header(len(room_name_tobyte),1,2,len(body_json_encoded))
+        #     member_response_body = room_name_tobyte + body_json_encoded
+        #     self.socket.sendto(member_response_header+member_response_body, client_address)
         #     print(self.chat_rooms)
 
 
@@ -399,6 +401,12 @@ class tcp_Server:
 
         return room_name_size + operation + state + operation_payload_size
 
+    # def custom_tcp_body_by_json(self, status_code, token):
+    #     body_json = {
+    #         "status_code" : status_code,
+    #         "user_token": token
+    #     }
+    #     return body_json
 
 
 def generate_user_token():

--- a/server.py
+++ b/server.py
@@ -62,8 +62,8 @@ class udp_Server():
                 state = int.from_bytes(header[2:3], byteorder='big')
                 print('state: received {} bytes data: {}'.format(
                     len(header[2:3]), state))
-                
-                
+
+
 
                 operation_payload_size = int.from_bytes(header[3:32], byteorder='big')
                 print('payload_size: received {} bytes data: {}'.format(
@@ -80,6 +80,9 @@ class udp_Server():
 
                 if operation == 1:
                     self.initialize_chat_room(room_name, operation_payload, client_address)
+                elif operation == 2:
+                    self.join_chat_room(room_name, operation_payload, client_address)
+
 
                 print(self.user_tokens)
 
@@ -175,7 +178,7 @@ class udp_Server():
         #header = self.custom_tcp_header(len(room_name),1,1,len(operation_payload_tobyte))
         # bodyの作成
         #body = self.encoder(room_name, 1) + self.encoder(username, 1)
-        
+
 
         #self.socket.sendto(header+body, client_address)
         #host_token = generate_user_token()
@@ -218,7 +221,7 @@ class tcp_Server:
 
         print('TCP Server started. It is on {}, port {}'.format(self.address, self.port))
 
-        
+
     # def encoder(self, data: str) -> bytes:
     #     return data.encode(encoding='utf-8')
 
@@ -250,8 +253,8 @@ class tcp_Server:
         thread_chat = threading.Thread(target=self.handle_chat_connection, daemon=True)
         thread_chat.start()
         thread_chat.join()
-        return    
-    
+        return
+
     def handle_chat_connection(self):
         # Handle the client connection
         try:
@@ -266,7 +269,7 @@ class tcp_Server:
             print('closing socket')
             self.socket.close()
 
-    
+
 
     def process_message(self, data, client_address):
         # Process the received message
@@ -336,11 +339,33 @@ class tcp_Server:
         # Send the message
         self.socket.sendto(token_response_header + body, client_address)
 
+
+
+
+
     def handle_token_response(self, room_name, token, client_address):
         # 新しいユーザーがチャットルームに参加したときに呼び出される関数
         print('Handle token response.')
 
         # Process the token and perform necessary actions
+
+    # def join_chat_room(self, room_name, username, client_address):
+    #     print('Start join room.')
+    #     operation_payload = 200
+    #     operation_payload_tobyte = operation_payload.to_bytes(1, byteorder='big')
+
+    #     header = self.custom_tcp_header(0,1,1,len(operation_payload_tobyte))
+    #     body = operation_payload_tobyte
+    #     self.socket.sendto(header+body, client_address)
+
+    #     visitor_token = generate_user_token()
+    #     token_tobyte = self.encoder(visitor_token, 1)
+    #     room_name_tobyte = self.encoder(room_name, 1)
+    #     token_response_header = self.custom_tcp_header(len(room_name_tobyte),1,2,len(token_tobyte))
+    #     token_response_body = room_name_tobyte + token_tobyte
+
+    #     self.socket.sendto(token_response_header+token_response_body, client_address)
+
 
     def custom_tcp_header(self, room_name_size, operation, state, operation_payload_size):
         # Create the custom TCP header
@@ -367,9 +392,3 @@ def main():
 
 if __name__ == '__main__':
     main()
-
-
-
-
-
-

--- a/server.py
+++ b/server.py
@@ -21,6 +21,7 @@ class udp_Server():
         self.active_clients = {}
         # ユーザー名とトークンを関連付ける
         self.user_tokens = {}
+        self.chat_rooms = {}
 
     def start(self):
         # 受信を待ち受ける処理とタイムアウトのチェック処理を並列実行する
@@ -47,6 +48,7 @@ class udp_Server():
                 print('received {} bytes from {}'.format(
                     len(data), client_address))
                 print(data)
+
 
                 # データ解析
                 header = data[:32]
@@ -330,6 +332,14 @@ class tcp_Server:
         host_token = generate_user_token()
         self.user_tokens[host_token] = username
 
+        # self.chat_rooms[room_name] = {'host' : set(), 'members': set()}
+        # self.chat_rooms[room_name]['host'].add((host_token, username))
+        # self.chat_rooms[room_name]['members'].add((host_token, client_address))
+
+        # print(self.chat_rooms)
+
+
+
         # Return the response with the host token
         token_tobyte = self.encoder(host_token, 1)
         room_name_tobyte = self.encoder(room_name, 1)
@@ -358,13 +368,26 @@ class tcp_Server:
     #     body = operation_payload_tobyte
     #     self.socket.sendto(header+body, client_address)
 
-    #     visitor_token = generate_user_token()
-    #     token_tobyte = self.encoder(visitor_token, 1)
-    #     room_name_tobyte = self.encoder(room_name, 1)
-    #     token_response_header = self.custom_tcp_header(len(room_name_tobyte),1,2,len(token_tobyte))
-    #     token_response_body = room_name_tobyte + token_tobyte
+        # roomが見つからなかったとき、404レスポンス
+        # try:
+        #     visitor_token = generate_user_token()
+        #     token_tobyte = self.encoder(visitor_token, 1)
+        #     room_name_tobyte = self.encoder(room_name, 1)
+        #     self.chat_rooms[room_name]['members'].add((visitor_token, client_address))
 
-    #     self.socket.sendto(token_response_header+token_response_body, client_address)
+        # except KeyError:
+        #     print('ルームが存在しない')
+        #     operation_payload = 403
+        #     operation_payload_tobyte =self.encoder(operation_payload, 2)
+        #     header = self.custom_tcp_header(0,2,2,len(operation_payload_tobyte))
+        #     body = operation_payload_tobyte
+        #     self.socket.sendto(header+body, client_address)
+
+        # else:
+        #     token_response_header = self.custom_tcp_header(len(room_name_tobyte),1,2,len(token_tobyte))
+        #     token_response_body = room_name_tobyte + token_tobyte
+        #     self.socket.sendto(token_response_header+token_response_body, client_address)
+        #     print(self.chat_rooms)
 
 
     def custom_tcp_header(self, room_name_size, operation, state, operation_payload_size):


### PR DESCRIPTION
# 概要
- クライアントがサーバーへチャットルーム参加のリクエストを送る
- サーバーはチャットルーム参加のためのトークンをクライアントへ送る

# 確認方法
- コード上で実装齟齬がないかご確認をお願いいたします。


# 実装内容

### client.py

- [ ] ①処理開始時にchatroomを新規作成か参加かCLI上で選ぶ処理の追加

- [ ] def send_username
　- 上記①で選ばれた処理によってheaderのoperation を変更できるよう修正
　- 動作確認中にdef sendmessage()が使われていない(send_username()で処理できている)ように見えたのでコメントアウト化

- [ ] def send_username
    - 参加のmessageをサーバーに送れるように、引数と送信時のbodyを修正
    - サーバーからの返答をjsonで受け取るように変更
      - サーバーが送信するものが、トークンの場合(string)とステータスコード(int)のみが出てきたため、decoderで条件分けしながら処理を継続する実装が難しく、一度jsonで受け取りjsonをdecodeし、jsonの中身を見て後続の処理を行う形にしました。
      - もっとよい実装があればそちらで検討したいです。
    - jsonからステータスコードを取得し、処理を継続するかリトライするかを決める処理の実装 

- [ ]  def select_action_mode、def input_room_name、def tcpr_end_udp_start
　- 上記実装を実現するために必要な処理を関数化


### server.py

- [ ] tcp class側に変更を入れました。
- [ ] def initialize_chat_room
  - レスポンスのbodyをjson化
  - 新規チャットルームを作成し、リストへ登録する(self.chat_rooms = {})処理の追加
  - 例えば、room名:recursion-team-dev, host名：suzuki, token:test, address:0.0.0.0/9001の場合、下記のように入る想定です。
 ```
chat_rooms = {
    'recursion-team-dev': {
        'host': {('test', 'suzuki')},
        'members': {('test', ('0.0.0.0', 9001))}
    }
}
  ```

- [ ] def handle_token_response
  - レスポンスbodyをjson化
  - チャットルームが見つからない場合、ステータスコード404を返却
  - チャットルームに参加する際、リストへ登録する(self.chat_rooms = {})処理を新規作成
  - 例えば、room名:recursion-team-dev, 名前：kato, token:test3, address:0.0.0.4/9001の場合、下記のように入る想定です。
 ```
chat_rooms =　{
    'recursion-team-dev': {
        'host': {('test', 'suzuki')},
        'members': {
            ('test', ('0.0.0.0', 9001)),
            ('test3', ('0.0.0.4', 9001))
        }
    }
}
```

### 懸念点
- chat_roomsは現在tcp_serverのクラスに持たせています。しかしudp_serverも参照、更新する可能性がありそうなため、別クラス切り出したほうがよいのか、別の実装のほうがよいのか考えています。
