### PR TITLE
UDPサーバーのパケット受信とリレーションシステム削除 

### DIFF
--- a/server.py
+++ b/server.py
@@ -88,18 +88,21 @@ class udp_Server():
                 print('token: received {} bytes data: {}'.format(len(body[room_name_size:room_name_size + token_size]), token))
 
                 message_byte = body[room_name_size + token_size:]
-                message = self.decoder(message_byte, 'str')
-                print('message: received {} bytes data: {}'.format(len(body[room_name_size + token_size:]), message))
-
-                if message == '[remove_chatroom]':
-                    target_room = self.chat_rooms[room_name]
-                    user_info = (token, client_address)
-                    if target_room['host'] == user_info:
-                        self.chat_rooms.remove_chatroom(self, room_name, token, client_address)
-                    else:
-                        self.chat_rooms.remove_member_from_chatroom(self, room_name, token, client_address)
+                if(len(message_byte) > 4094):
+                    raise ValueError('The length of room name is too long.')
                 else:
-                    self.multicast_send(message, room_name)
+                    message = self.decoder(message_byte, 'str')
+                    print('message: received {} bytes data: {}'.format(len(body[room_name_size + token_size:]), message))
+
+                    if message == '[remove_chatroom]':
+                        target_room = self.chat_rooms[room_name]
+                        user_info = (token, client_address)
+                        if target_room['host'] == user_info:
+                            self.chat_rooms.remove_chatroom(self, room_name, token, client_address)
+                        else:
+                            self.chat_rooms.remove_member_from_chatroom(self, room_name, token, client_address)
+                    else:
+                        self.multicast_send(message, room_name)
 
                 # データ準備
                 # username_len = int.from_bytes(data[:1], byteorder='big')

--- a/server.py
+++ b/server.py
@@ -114,6 +114,7 @@ class udp_Server():
                         sent = self.socket.sendto(header + body, client_address)
 
                     else:
+                        self.chat_rooms[room_name]['timestamp'][token] = time.time()
                         self.multicast_send(message, room_name)
 
                 # データ準備


### PR DESCRIPTION
# 概要(#13 )
- UDPサーバーのパケット受信
- リレーションシステム構築
- その他、レスポンス時に必要な項目の追加

# 確認方法
- コードをご確認いたします。

# 実装内容

### client.py
- 修正なし。client.pyがtcp,udpで分割された後、tcp側に接続を切る処理を入れたいと考えています。


### server.py

- [ ] def receive_message(self):
  -  メッセージを受け取り、解析する部分の追加
  - 接続解除時の処理とメッセージ送信部分を追加
 
- [ ]  multicast_send
  - room全員にメッセージを送信する。
- [ ] check_inactive_clients
  - 時間ごとに非アクティブユーザを検知する関数
  - 全ての疎通が問題なく動いた際は、別スレッドで立ち上げる処理を書いて動かせるようにしたいと考えています。
- [ ] class chat_room
　- メッセージ送信時刻を保持するようにトークンとtimestampをタプルでもつように機能拡張
　- メンバーがルームを退出するとき、リレーションから削除する処理の追加
　- ホストが抜けるとき、ルームごと消す処理の追加