### PR TITLE
サーバーがtcpで複数通信を受けられるように変更

### DIFF
--- a/client.py
+++ b/client.py
@@ -199,7 +199,7 @@ class TCPClient:
 
         finally:
             print('closing socket')
-            # self.socket.close()
+            self.socket.close()
 
 
 

--- a/server.py
+++ b/server.py
@@ -348,17 +348,18 @@ class tcp_Server:
 
     def start(self):
         # Start the TCP server
-        thread_chat = threading.Thread(target=self.handle_chat_connection, daemon=True)
-        thread_chat.start()
-        thread_chat.join()
+        while True:
+            client_socket, client_address = self.socket.accept()
+            thread_chat = threading.Thread(target=self.handle_chat_connection, args=(client_socket, client_address), daemon=True)
+            thread_chat.start()
+            thread_chat.join()
         return
 
-    def handle_chat_connection(self):
+    def handle_chat_connection(self, client_socket, client_address):
     # Handle the client connection
         try:
-            while True:
+            #while True:
                 print('\nwaiting for a tcpclient connection')
-                client_socket, client_address = self.socket.accept()
                 print('connection from', client_address)
                 print("client_socket: ", client_socket)
                 data = client_socket.recv(tcp_Server.buffer_size)
@@ -367,7 +368,7 @@ class tcp_Server:
                 client_socket.close()
         finally:
             print('closing socket')
-            self.socket.close()
+            #self.socket.close()
 
 
 
@@ -487,8 +488,10 @@ class tcp_Server:
 
             # Send the message
             client_socket.sendall(token_response_header + body)
-            udp_server = udp_Server(self.chat_room_list)
-            udp_server.start()
+            # udp_server = udp_Server(self.chat_room_list)
+            # udp_server.start()
+            # thread_udp_server = threading.Thread(target=udp_server.start, daemon=True)
+            # thread_udp_server.start()
 
 
     def handle_token_response(self, room_name, state, username, client_socket):
@@ -633,11 +636,24 @@ def main():
 
     # チャットルーム作成/接続のためのサーバーを立ち上げる
     tcp_server = tcp_Server(chat_room_list)
-    tcp_server.start()
+    udp_server = udp_Server(chat_room_list)
+
+    thread_tcp_server = threading.Thread(target=tcp_server.start, daemon=True)
+    thread_udp_server = threading.Thread(target=udp_server.start, daemon=True)
+
+    thread_udp_server.start()
+
+    thread_tcp_server.start()
+
+    thread_udp_server.join()
+    thread_tcp_server.join()
+
+
+
     # udp_server = udp_Server()
     # udp_server.start()
-    #udp_server = udp_Server(chat_room_list)
-    #udp_server.start()
+    # udp_server = udp_Server(chat_room_list)
+    # udp_server.start()
 
     #tcp_server = tcp_Server(chat_room_list)
 


### PR DESCRIPTION
下記画像のように通信を受けられるように変更しました。

画像のターミナルは、
•左がserver 

•真ん中がclient1(ルーム作成と「こんにちは」とメッセージを送る

•右がclient2(ルーム参加と「こんにちはtest1」とメッセージをサーバーに送る

です。

2枚目の画像は1枚目の画像の続きです。

serverでは、1枚目の画像でclient1とtcp通信を行い、2枚目の画像でclient2とtcp通信を行っている様子がログに出ています！

2枚目の画像の1番下あたりでserverが2つのクライアントにメッセージを送っているのが確認できるので、リレーシステムも動いていそうです！


<img width="1292" alt="スクリーンショット 2023-12-15 7 46 22" src="https://github.com/teamdev-A-backend/online-chat-messenger/assets/75150015/2c666f5c-301a-4f12-ac9e-3ccadee8662f">
<img width="1440" alt="スクリーンショット 2023-12-15 7 46 29" src="https://github.com/teamdev-A-backend/online-chat-messenger/assets/75150015/84a8fc8f-21b8-4bd7-ada6-fef9e8e278cf">

# 変更点
昨日の打ち合わせをもとに下記のように変えてみました。

### server.py

①main()の中でtcp,udpのスレッドが動くように変更。
→各スレッドでtcp,udpの無限ループの処理を動かせるようにするため。
→tcp側も無限ループしたいが、tcpの中でudpを生成すると、udpが無限ループしている影響で、tcpの処理が終わらないように昨日の打ち合わせで3人で確認した時に見えたため。

②tcp classについて、以下の流れになるように修正

無限ループスタート
↓
self.socket.accept()で通信の受付待機
↓
thread_chatで受付した通信でスレッドを新たに開始し、ルーム新規作成または参加の処理実行。
↓
client_socket.close()でself.socket.accept()していたクライアントとのsocketを閉じる。
(これを閉じないと一度接続したクライアントのアドレスで無限ループしているように見えました。)


⚪︎サーバーのスレッドは下記の感じで動いているように見えました。主に3つのスレッドが動いているイメージを持っています。

①tcp通信用のスレッド
　L ①の中で③チャットルーム新規作成または参加のスレッド(無限ループ)

②udp通信用のスレッド(メッセージを受け取る関数が無限ループ)


### client.py
tcpで使っていたsocketが閉じていなそうに見えたので閉じるように明示的に記載してみました。

### 懸念点
•client.pyで送信したメッセージと受け取ったメッセージは分かりやすくした方が良さそうと思いました。

•打ち合わせでも上がっていたメッセージを入力してください。を意味する英語メッセージが1回しか出てこない点

•チャットルーム新規作成または参加のスレッドは使い終わったら閉じる方がよいのか。

•チャットルームから抜ける処理をつける必要があるかもで